### PR TITLE
Append folder name if multiple files with same name are open

### DIFF
--- a/src/openfiles.ts
+++ b/src/openfiles.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as mkdirp from 'mkdirp';
-import * as rimraf from 'rimraf';
 import { window, commands, Disposable, Command, workspace } from 'vscode';
 
 export class TreeItemFile extends vscode.TreeItem {

--- a/src/openfiles.ts
+++ b/src/openfiles.ts
@@ -11,7 +11,7 @@ export class TreeItemFile extends vscode.TreeItem {
 		public readonly unique: boolean
 	) {
 		super(document.uri, vscode.TreeItemCollapsibleState.None);
-		this.id = document.uri
+		this.id = document.uri.path
 		this.label = path.basename(this.document.uri.path);
 		this.dirname = path.dirname(this.document.uri.path);
 		if (!unique) this.label += ` – ${path.basename(this.dirname)}`;
@@ -210,7 +210,7 @@ export class OpenFiles implements vscode.TreeDataProvider<TreeItemFile|TreeItemG
 			documentsByName[name].push(document)
 		}
 
-		for (const [name, documents] of Object.entries(documentsByName)) {
+		for (const [name, documents] of (<any>Object).entries(documentsByName)) {
 			for (const document of documents) {
 				if (document.languageId !== group.label || document.isClosed) {
 					continue;

--- a/src/openfiles.ts
+++ b/src/openfiles.ts
@@ -8,18 +8,21 @@ import { window, commands, Disposable, Command, workspace } from 'vscode';
 export class TreeItemFile extends vscode.TreeItem {
 
 	constructor(
-		public readonly document: vscode.TextDocument
+		public readonly document: vscode.TextDocument,
+		public readonly unique: boolean
 	) {
 		super(document.uri, vscode.TreeItemCollapsibleState.None);
+		this.id = document.uri
 		this.label = path.basename(this.document.uri.path);
 		this.dirname = path.dirname(this.document.uri.path);
+		if (!unique) this.label += ` – ${path.basename(this.dirname)}`;
 	}
 
 	contextValue: string = 'file';
 	label: string = '';
 	dirname: string = '';
 	ext: string = '';
-	
+
 	get command(): Command {
 		return {
 			command: 'extension.openfiles.SelectItem',
@@ -82,7 +85,6 @@ export class OpenFiles implements vscode.TreeDataProvider<TreeItemFile|TreeItemG
 		this.context.subscriptions.push.apply(this.context.subscriptions, [
 
 			commands.registerCommand('extension.openfiles.SelectItem', (document: vscode.TextDocument) => {
-				console.log(document);
 				window.showTextDocument(document);
 			}),
 
@@ -201,13 +203,23 @@ export class OpenFiles implements vscode.TreeDataProvider<TreeItemFile|TreeItemG
 
 	async getChildrenFromGroup(group: TreeItemGroup): Promise<(TreeItemFile)[]> {
 		let result: TreeItemFile[] = [];
-		for (let document of this.textDocuments) {
-			if (document.languageId !== group.label || document.isClosed) {
-				continue; 
+
+		const documentsByName = {};
+		for (const document of this.textDocuments) {
+			const name = path.basename(document.uri.path);
+			if (!documentsByName[name]) documentsByName[name] = []
+			documentsByName[name].push(document)
+		}
+
+		for (const [name, documents] of Object.entries(documentsByName)) {
+			for (const document of documents) {
+				if (document.languageId !== group.label || document.isClosed) {
+					continue;
+				}
+				let item = new TreeItemFile(document, documents.length === 1);
+				group.items.push(item);
+				result.push(item);
 			}
-			let item = new TreeItemFile(document);
-			group.items.push(item);
-			result.push(item);
 		}
 
 		result = result.sort((left, right) => {
@@ -225,7 +237,7 @@ export class OpenFiles implements vscode.TreeDataProvider<TreeItemFile|TreeItemG
 		if (element instanceof vscode.TreeItem) {
 			return <vscode.TreeItem>element;
 		} else {
-			return new TreeItemFile(<vscode.TextDocument>element);
+			return new TreeItemFile(<vscode.TextDocument>element, true);
 		}
 	}
 


### PR DESCRIPTION
Note: All code is in this PR is authored by @alexanderweiss and is introduced here: https://github.com/Divni/vscode-open-files/issues/2#issuecomment-476852566. I'm making the PR because I think the published extension should have this feature!

| Before    | After    |
| ----------| -------- |
| ![before] | ![after] |

[before]: https://user-images.githubusercontent.com/1570168/56997828-f0f17f80-6b5d-11e9-82c9-a26fe330a705.png
[after]: https://user-images.githubusercontent.com/150396/55033378-55776700-5013-11e9-8958-f897301fa01c.png


Fixes #2.